### PR TITLE
Separate and Highlight unreachable nodes

### DIFF
--- a/monitor/assets/stylesheet.css
+++ b/monitor/assets/stylesheet.css
@@ -278,7 +278,7 @@ h5 {
     padding: 0;
     margin-right: 2px;
     margin-bottom: 2em;
-    width: 5em;
+    width: 10em;
 }
 
 
@@ -287,11 +287,11 @@ h5 {
     text-align: center;
     display: flex;
     flex-direction: column;
-    width: 18em;
+    width: 20em;
     color: black;
     font-weight: 900;
     font-size: 1rem;
-    height: 6em;
+    height: 10em;
     border: 0;
     opacity: 0.9;
 }
@@ -410,13 +410,13 @@ h5 {
     font-style: italic;
 }
 
-/* Unreachable node elements */
-#unreachable-list .node-row {
+/* Unconnected node elements */
+#unconnected-list .node-row {
     background-color: rgba(255,0,0,.5);
     color: white;
 }
 
-#unreachable-list a {
+#unconnected-list a {
     color: white;
 }
 

--- a/monitor/assets/stylesheet.css
+++ b/monitor/assets/stylesheet.css
@@ -406,6 +406,20 @@ h5 {
     display: flex;
 }
 
+.nodes-list-description {
+    font-style: italic;
+}
+
+/* Unreachable node elements */
+#unreachable-list .node-row {
+    background-color: rgba(255,0,0,.5);
+    color: white;
+}
+
+#unreachable-list a {
+    color: white;
+}
+
 /*#top-stakers-graph {*/
 /*    flex-basis: 10%;*/
 /*}*/

--- a/monitor/components.py
+++ b/monitor/components.py
@@ -10,6 +10,14 @@ import nucypher
 
 NODE_TABLE_COLUMNS = ['Status', 'Checksum', 'Nickname', 'Uptime', 'Last Seen', 'Fleet State']
 
+NODE_LABEL_DESCRIPTIONS = {
+    'confirmed': "Nodes that confirmed activity for the next period",
+    'pending': "Nodes that previously confirmed activity for the current period but not for the next period",
+    'idle': "Nodes that have never confirmed activity",
+    'unconfirmed': "Nodes that have previously confirmed activity but have missed multiple periods since then",
+    'unreachable':  "Nodes that are currently unreachable by the monitor",
+}
+
 
 def header() -> html.Div:
     return html.Div([html.Div(f'v{nucypher.__version__}', id='version')], className="logo-widget")
@@ -84,36 +92,45 @@ def generate_node_row(node_info: dict) -> dict:
     staker_address = node_info['staker_address']
     etherscan_url = f'https://goerli.etherscan.io/address/{node_info["staker_address"]}'
 
-    try:
-        slang_last_seen = MayaDT.from_rfc3339(node_info['last_seen']).slang_time()
-    except ParserError:
-        # Show whatever we have anyways
-        slang_last_seen = str(node_info['last_seen'])
+    slang_last_seen = get_last_seen(node_info)
 
     status = generate_node_status_icon(node_info['status'])
 
     # Uptime
-    king = 'uptime-king' if node_info.get('uptime_king') else ''
-    baby = 'newborn' if node_info.get('newborn') else ''
-    king_or_baby = king or baby
-    uptime_cell = html.Td( html.Span(node_info['uptime']), className='uptime-cell', id=king_or_baby, title=king_or_baby),
+    #king = 'uptime-king' if node_info.get('uptime_king') else ''
+    #baby = 'newborn' if node_info.get('newborn') else ''
+    #king_or_baby = king or baby
+    #uptime_cell = html.Td( html.Span(node_info['uptime']), className='uptime-cell', id=king_or_baby, title=king_or_baby),
     components = {
         'Status': status,
         'Checksum': html.Td(html.A(f'{staker_address[:10]}...', href=etherscan_url, target='_blank'), className='node-address'),
         'Nickname': identity,
-        'Uptime': uptime_cell,
+        'Uptime': html.Td(html.Span(node_info['uptime']), className='uptime-cell'),
         'Last Seen': html.Td([slang_last_seen]),
         'Fleet State': fleet_state,
-        'Peers ': html.Td(node_info['peers']),
+        #'Peers ': html.Td(node_info['peers']),
     }
 
     return components
 
 
-def nodes_table(nodes) -> html.Table:
+def get_last_seen(node_info):
+    try:
+        slang_last_seen = MayaDT.from_rfc3339(node_info['last_seen']).slang_time()
+    except ParserError:
+        # Show whatever we have anyways
+        slang_last_seen = str(node_info['last_seen'])
+    return slang_last_seen
+
+
+def nodes_table(nodes, track_unreachable_nodes: bool = True) -> (html.Table, List):
     rows = []
+    unreachable_nodes = [] if track_unreachable_nodes else None
     for index, node_info in enumerate(nodes):
         row = list()
+        if track_unreachable_nodes and 'No Connection' in get_last_seen(node_info):
+            unreachable_nodes.append(node_info)
+            continue
         components = generate_node_row(node_info=node_info)
         for col in NODE_TABLE_COLUMNS:
             cell = components[col]
@@ -121,16 +138,39 @@ def nodes_table(nodes) -> html.Table:
         style_dict = {'overflowY': 'scroll'}
         rows.append(html.Tr(row, style=style_dict, className='node-row'))
     table = html.Table(rows, id='node-table')
-    return table
+    return table, unreachable_nodes
 
 
 def known_nodes(nodes_dict: dict, teacher_checksum: str = None) -> List[html.Div]:
     components = list()
+    unreachable_nodes = list()
+
+    # nodes
     for label, nodes in list(nodes_dict.items()):
-        component = html.Div([
-            html.H4(f'{label.capitalize()} Nodes ({len(nodes)})'),
-            html.Br(),
-            html.Div([nodes_table(nodes)])
-        ], id=f"{label}-list")
+        component, unreachable = nodes_list_section(label, nodes)
+        unreachable_nodes += unreachable
         components.append(component)
+
+    # unreachable nodes
+    if len(unreachable_nodes) > 0:
+        label = 'unreachable'
+        component, _ = nodes_list_section(label, unreachable_nodes, track_unreachable_nodes=False)
+        components.append(component)
+
     return components
+
+
+def nodes_list_section(label, nodes, track_unreachable_nodes: bool = True):
+    table, unreachable_nodes = nodes_table(nodes, track_unreachable_nodes=track_unreachable_nodes)
+    try:
+        label_description = NODE_LABEL_DESCRIPTIONS[label]
+    except KeyError:
+        label_description = None
+
+    component = html.Div([
+        html.H4(f'{label.capitalize()} Nodes ({len(nodes)})'),
+        html.P(label_description, className='nodes-list-description'),
+        html.Br(),
+        html.Div([table])
+    ], id=f"{label}-list")
+    return component, unreachable_nodes


### PR DESCRIPTION
Fixes #25 

- [x] Separate and highlight unreachable nodes from other nodes - (addendum: renamed "unreachable" to 'unconnected" and updated description)
- [x] Add descriptions to status sections so that they are better understood

<img width="1394" alt="Screen Shot 2020-01-27 at 5 12 28 PM" src="https://user-images.githubusercontent.com/19150641/73218880-dc600900-4128-11ea-99a3-17ba29e115fe.png">
<img width="1432" alt="Screen Shot 2020-01-28 at 12 08 24 PM" src="https://user-images.githubusercontent.com/19150641/73287260-fe0fcd80-41c6-11ea-945f-b105f7bd75f4.png">
