### PR TITLE
Update calculation of months transpired since launch for `/supply_information` endpoint

### DIFF
--- a/monitor/supply.py
+++ b/monitor/supply.py
@@ -38,21 +38,16 @@ def months_transpired_since_launch(now: MayaDT) -> int:
     """
     days_transpired = (now - LAUNCH_DATE).days
     months_transpired = days_transpired / DAYS_PER_MONTH
-    months_transpired_floor = math.floor(months_transpired)
-    months_transpired_round = round(months_transpired)
-    if months_transpired_floor == months_transpired_round:
-        # same value so life is easy i.e. round function rounded down
-        return months_transpired_round
-    else:
-        # round function rounded up - we are somewhere in duration between floor and ceil
-        # calculation done during allocation
-        rounded_up_months_min_duration_days = round(months_transpired_round * DAYS_PER_MONTH)
 
-        if rounded_up_months_min_duration_days <= days_transpired:
-            return months_transpired_round
-        else:
-            # required days not yet surpassed for subsequent month - use floor value
-            return months_transpired_floor
+    months_transpired_ceil = math.ceil(months_transpired)
+    # calculation of vesting days (based on months) done during allocation
+    rounded_up_months_min_duration_days = round(months_transpired_ceil * DAYS_PER_MONTH)
+
+    if rounded_up_months_min_duration_days <= days_transpired:
+        return months_transpired_ceil
+    else:
+        # required days not yet surpassed for subsequent month - use floor value
+        return math.floor(months_transpired)
 
 
 def vesting_remaining_factor(vesting_months: int,

--- a/monitor/supply.py
+++ b/monitor/supply.py
@@ -1,3 +1,4 @@
+import math
 from collections import OrderedDict
 from typing import Union, Optional, Dict
 
@@ -31,7 +32,27 @@ DAYS_PER_MONTH = 30.416  # value used in csv allocations
 
 
 def months_transpired_since_launch(now: MayaDT) -> int:
-    return round((now - LAUNCH_DATE).days / DAYS_PER_MONTH)
+    """
+    Determines the number of months transpired since the launch date, Oct 15, 2020 00:00:00 UTC, based on how
+    monthly durations were calculated when allocations were distributed.
+    """
+    days_transpired = (now - LAUNCH_DATE).days
+    months_transpired = days_transpired / DAYS_PER_MONTH
+    months_transpired_floor = math.floor(months_transpired)
+    months_transpired_round = round(months_transpired)
+    if months_transpired_floor == months_transpired_round:
+        # same value so life is easy i.e. round function rounded down
+        return months_transpired_round
+    else:
+        # round function rounded up - we are somewhere in duration between floor and ceil
+        # calculation done during allocation
+        rounded_up_months_min_duration_days = round(months_transpired_round * DAYS_PER_MONTH)
+
+        if rounded_up_months_min_duration_days <= days_transpired:
+            return months_transpired_round
+        else:
+            # required days not yet surpassed for subsequent month - use floor value
+            return months_transpired_floor
 
 
 def vesting_remaining_factor(vesting_months: int,

--- a/tests/test_supply.py
+++ b/tests/test_supply.py
@@ -27,14 +27,19 @@ def test_months_transpired():
 
 def test_months_transpired_rounding_days():
     # ensure months transpired match calculation used for locked periods for allocations
-    max_locked_months = 5*12  # 5 years of time
-    for i in range(1, max_locked_months+1):
-        for j in range(1, 30):
-            # each day within month
-            lock_periods_used_in_allocation = round(i * DAYS_PER_MONTH) + j  # calculation used in allocations
-            months_transpired = months_transpired_since_launch(LAUNCH_DATE.add(days=lock_periods_used_in_allocation))
-            # ensure that calculation of months matches calculation used for locked periods
-            assert months_transpired == i, f"{i} months {j} days transpired"
+    max_locked_days = 6 * 365  # each day for 6 years (extra time for solid test)
+    current_expected_months_transpired = 0
+    next_expected_month_days_transpired = round(1 * DAYS_PER_MONTH)  # same as allocation calc
+    for days_transpired in range(1, max_locked_days+1):
+        months_transpired = months_transpired_since_launch(LAUNCH_DATE.add(days=days_transpired))
+        if days_transpired < next_expected_month_days_transpired:
+            assert months_transpired == current_expected_months_transpired, f"{days_transpired} days transpired"
+        else:
+            # we've transitioned to the next month
+            current_expected_months_transpired += 1
+            assert months_transpired == current_expected_months_transpired, f"{days_transpired} days transpired"
+            # same as allocation calc
+            next_expected_month_days_transpired = round((current_expected_months_transpired+1) * DAYS_PER_MONTH)
 
 
 def test_vesting_remaining_factor_24_months():

--- a/tests/test_supply.py
+++ b/tests/test_supply.py
@@ -17,11 +17,24 @@ TEST_REWARDS_PER_MONTH = NU(83_333, 'NU')
 
 def test_months_transpired():
     # ensure months transpired match calculation used for locked periods for allocations
-    max_locked_months = 5*12
+    max_locked_months = 5*12  # 5 years of time
     for i in range(1, max_locked_months+1):
         lock_periods_used_in_allocation = round(i * DAYS_PER_MONTH)  # calculation used in allocations
         months_transpired = months_transpired_since_launch(LAUNCH_DATE.add(days=lock_periods_used_in_allocation))
-        assert months_transpired == i  # ensure that calculation of months matches calculation used for locked periods
+        # ensure that calculation of months matches calculation used for locked periods
+        assert months_transpired == i, f"{i} months transpired"
+
+
+def test_months_transpired_rounding_days():
+    # ensure months transpired match calculation used for locked periods for allocations
+    max_locked_months = 5*12  # 5 years of time
+    for i in range(1, max_locked_months+1):
+        for j in range(1, 30):
+            # each day within month
+            lock_periods_used_in_allocation = round(i * DAYS_PER_MONTH) + j  # calculation used in allocations
+            months_transpired = months_transpired_since_launch(LAUNCH_DATE.add(days=lock_periods_used_in_allocation))
+            # ensure that calculation of months matches calculation used for locked periods
+            assert months_transpired == i, f"{i} months {j} days transpired"
 
 
 def test_vesting_remaining_factor_24_months():


### PR DESCRIPTION
One of the interesting things here is that in our sub-stake allocation calculations we did the following for determining the locked periods for a sub-stake, `round(i * 30.416)`
- 30.416 is 365/12 i.e. an average of the number of days in a month
- `i` is the number of months for the duration.

Eg. for 24-month allocation eg. SAFT2 we did
- Sub-stake_1 had a duration of 1 month i.e. `round(1 * 30.416)` = 30 locked periods
- Sub-stake_2 had a duration of 2 months i.e `round(2 * 30.416)` = 61 locked periods
- Sub-stake_3 had a duration of 3 months i.e. `round(3 * 30.416)` = 91 locked periods
...
- Sub-stake_24 had a duration of 24 months i.e. `round(24 * 30.416)` = 730 locked periods

Therefore when trying to do the opposite for the `supply_information` endpoint for determining number of already vested tokens i.e. using how many months have transpired based on the number of days since launch, our calculation becomes tricky, because the original calculation of number of periods may have rounded up or down. We want to know given that the time is today, and x periods (days) have transpired since launch, how many months of vesting have occurred and therefore we can determine the number of tokens that have now become unlocked.

Determining the days transpired since launch is easy since the number of days can be determined by a maya datetime.  However, when determining the number of months from those days, the calculation becomes nuanced.

A simple solution is `days_transpired / 30.416` for the number of months transpired but this is a float - do we round up or down? Because the original calculation that was done (`round(months * 30.416)`) can round up or down, we need to do some extra work.

Take the scenario where 30 days have transpired since launch, 
- months_transpired = `30 / 30.416` = 0.9863 months.
- If we just round down, then technically this is 0 months of vesting, however, it should be 1 month because `round(1 * 30.416)` = 30 days. 
- I can't round up because it may work in this instance (after 30 days), but what if 90 days have passed:
    - `90 / 30.416` = 2.959 months which if I round up is 3. However for 3 months to pass from the allocations calculation `round(3 * 30.416)` = 91 days needs to have transpired but in this case, only 90 days have passed.

Therefore, to correctly calculate the months transpired based on the days transpired, I do the following:
1. calculate `actual_days_transpired`  using difference in maya datetime
2. determine months transpired without rounding i.e. `months_transpired = actual_days_transpired / 30.416`
2. round up the months transpired calculation i.e. `ceil_months_transpired = math.ceil(months_transpired)`
3. calculate the expected number of days to transpire for the rounded up months transpired based on the allocation calculation i.e. `expected_days_transpired = round(ceil_months_transpired * 30.416)`
4. Check whether `actual_days_transpired >= expected_days_transpired` (really just equality since actual_days_transpired can't be greater than expected_days_transpired because we use `ceil`)
    - If True -> then sufficient days have passed and return months transpired = ceil_months_transpired
    - If False -> then insufficient days have passed and months transpired should be rounded down i.e. = `math.floor(months_transpired)`

See the unit tests for some concrete examples of my thinking.