### PR TITLE
Rename "Staked Tokens" tile to better contextualize value

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,7 +11,7 @@ click==7.1.2
 coverage==5.3
 cryptography==3.1.1
 cytoolz==0.11.0
-dash-core-components==1.12.1
+dash-core-components==1.13.0
 dash-html-components==1.1.1
 dash-renderer==1.8.3
 dash-table==4.11.0

--- a/monitor/components.py
+++ b/monitor/components.py
@@ -52,9 +52,9 @@ NODE_STATUS_URL_TEMPLATE = "https://{}/status"
 NO_CONNECTION_TO_NODE = "No Connection to Node"
 NOT_YET_CONNECTED_TO_NODE = "Not Yet Connected to Node"
 
-
-def header() -> html.Div:
-    return html.Div([html.Div(f'v{nucypher.__version__}', id='version')], className="logo-widget")
+# TODO - not needed?
+# def header() -> html.Div:
+#     return html.Div([html.Div(f'v{nucypher.__version__}', id='version')], className="logo-widget")
 
 
 def make_contract_row(network: str, agent, balance: NU = None):

--- a/monitor/dashboard.py
+++ b/monitor/dashboard.py
@@ -256,7 +256,7 @@ class Dashboard:
         def staked_tokens(n, latest_crawler_stats):
             data = self.verify_cached_stats(latest_crawler_stats)
             staked = NU.from_nunits(data['global_locked_tokens'])
-            return html.Div([html.H4('Staked Tokens'), html.H5(f"{staked}", id='staked-tokens-value')])
+            return html.Div([html.H4('Staked in Current Period'), html.H5(f"{staked}", id='staked-tokens-value')])
 
         # @dash_app.callback(Output('locked-stake-graph', 'children'),
         #                    [Input('daily-interval', 'n_intervals')],

--- a/monitor/dashboard.py
+++ b/monitor/dashboard.py
@@ -143,9 +143,10 @@ class Dashboard:
         dash_app.title = settings.TITLE
         dash_app.layout = layout.BODY
 
-        @dash_app.callback(Output('header', 'children'), [Input('url', 'pathname')])  # on page-load
-        def header(pathname):
-            return components.header()
+        # TODO - not needed?
+        # @dash_app.callback(Output('header', 'children'), [Input('url', 'pathname')])  # on page-load
+        # def header(pathname):
+        #     return components.header()
 
         @dash_app.callback(Output('cached-crawler-stats', 'children'), [Input('request-interval', 'n_intervals')])
         def update_cached_stats(n_intervals):

--- a/monitor/layout.py
+++ b/monitor/layout.py
@@ -30,7 +30,7 @@ else:
 
 HEADER = html.Div([
     html.A(html.Img(src=LOGO_PATH, className='banner'), href='https://www.nucypher.com'),
-    html.Div(id='header'),
+    # html.Div(id='header'), TODO not needed?
     HIDDEN_BUTTONS],
     id="controls")
 


### PR DESCRIPTION
* Fixes #90 
   * Staked tokens are only for the current period, and the tile label should reflect that
* Resolve dependency discrepancy between standard and dev requirements. I didn't do a relock of dependencies because there were some issues with compatibility of dash[testing].
* Remove the `nucypher` version number since it isn't kept up to date as often and can lag behind the `nucypher` releases. Currently we show `v4.1.2` 😅 

I didn't do an overall relock of dependencies because there were some conflict issues due to the `dash[testing]` dependency and it's use of `cryptography`. This can be better addressed in a separate PR.
```
There are incompatible versions in the resolved dependencies:
  cryptography==3.0 (from dash[testing]==1.18.1->-r /var/folders/m1/5vfcwhnj7b39kdnz_cjf3rkm0000gn/T/pipenv5i7jkwburequirements/pipenv-a6hvkl9k-constraints.txt (line 5))
  cryptography>=1.3.4 (from requests[security]==2.21.0->dash[testing]==1.18.1->-r /var/folders/m1/5vfcwhnj7b39kdnz_cjf3rkm0000gn/T/pipenv5i7jkwburequirements/pipenv-a6hvkl9k-constraints.txt (line 5))
  cryptography>=3.2 (from pyopenssl==20.0.1->requests[security]==2.21.0->dash[testing]==1.18.1->-r /var/folders/m1/5vfcwhnj7b39kdnz_cjf3rkm0000gn/T/pipenv5i7jkwburequirements/pipenv-a6hvkl9k-constraints.txt (line 5))
  ```
   