### PR TITLE
Fix Top Stakers Chart and Current Staked tokens value

### DIFF
--- a/monitor/charts.py
+++ b/monitor/charts.py
@@ -2,6 +2,7 @@ import IP2Location
 import maya
 import plotly.graph_objs as go
 from dash import dcc
+from nucypher.blockchain.eth.token import NU
 
 GRAPH_CONFIG = {'displaylogo': False,
                 'autosizable': True,
@@ -79,12 +80,17 @@ def stakers_breakdown_pie_chart(data):
 
 
 def top_stakers_chart(data: dict):
-    data_values_list = list(data.values())
-    total_staked = sum(data_values_list)
+    # modify values to show 'NU'
+    stakes_in_nu = []
+    total_staked = 0
+    for stake_in_nunits in data.values():
+        stake_in_nu = NU.from_nunits(stake_in_nunits).to_tokens()
+        stakes_in_nu.append(stake_in_nu)
+        total_staked += stake_in_nu
 
     # add Total entry as root element
     treemap_labels = (list(data.keys()) + ['Total'])
-    treemap_values = data_values_list + [total_staked]
+    treemap_values = stakes_in_nu + [total_staked]
     treemap_parents = ['Total'] * len(data) + ['']  # set parent of Total entry to be root ('')
 
     fig = go.Figure(
@@ -95,7 +101,7 @@ def top_stakers_chart(data: dict):
             parents=treemap_parents,
             values=treemap_values,
             textinfo='none',
-            hovertemplate="<b>%{label} </b> <br> Stake Size: %{value:,.2f} NU<br> % of Network: %{percentRoot:.3% %}",
+            hovertemplate="<b>%{label} </b> <br> Stake Size: %{value:,.0f} NU<br> % of Network: %{percentRoot:.3%}",
             marker=go.treemap.Marker(colors=list(data.keys()), colorscale='Viridis', line={"width": 1}),
             pathbar=dict(visible=False),
         ),

--- a/monitor/dashboard.py
+++ b/monitor/dashboard.py
@@ -245,8 +245,16 @@ class Dashboard:
                            [State('cached-crawler-stats', 'children')])
         def staked_tokens(n, latest_crawler_stats):
             data = self.verify_cached_stats(latest_crawler_stats)
-            staked = NU.from_nunits(data['global_locked_tokens'])
+            staked = round(NU.from_nunits(sum(data['top_stakers'].values())), 2)  # round to 2 decimals
             return html.Div([html.H4('Staked in Current Period'), html.H5(f"{staked}", id='staked-tokens-value')])
+
+        @dash_app.callback(Output('staked-tokens-next-period', 'children'),
+                           [Input('minute-interval', 'n_intervals')],
+                           [State('cached-crawler-stats', 'children')])
+        def staked_tokens_next_period(n, latest_crawler_stats):
+            data = self.verify_cached_stats(latest_crawler_stats)
+            staked = round(NU.from_nunits(data['global_locked_tokens']), 2)  # round to 2 decimals
+            return html.Div([html.H4('Currently Staked for Next Period'), html.H5(f"{staked}", id='staked-tokens-next-period-value')])
 
         @dash_app.callback(Output('nodes-geolocation-graph', 'children'),
                            [Input('minute-interval', 'n_intervals')],

--- a/monitor/layout.py
+++ b/monitor/layout.py
@@ -42,6 +42,7 @@ STATS = html.Div([
             html.Div(id='domain'),
             html.Div(id='active-stakers'),
             html.Div(id='staked-tokens'),
+            html.Div(id='staked-tokens-next-period')
 ], id='stats')
 
 


### PR DESCRIPTION
- Fix token units and percentage values used in Top Stakers Chart. (Fixes #78 )
![Screen Shot 2021-10-14 at 3 04 35 PM](https://user-images.githubusercontent.com/19150641/137380006-9fd75de2-7364-4adf-ae8e-941532903031.png)


- Correctly show tokens staked for the current period vs currently staked for the next period. (Fixes #96 ).

![Screen Shot 2021-10-14 at 3 04 51 PM](https://user-images.githubusercontent.com/19150641/137380029-79ba36ea-2bb2-4c66-9209-28b9366c0a86.png)
