### PR TITLE
Updates to est_circulating_supply, max_supply values used in `/supply_information` endpoint

### DIFF
--- a/monitor/dashboard.py
+++ b/monitor/dashboard.py
@@ -26,9 +26,6 @@ class Dashboard:
     # static value from when halt NU inflation occurred - `self.staking_agent.contract.functions.currentMintingPeriod().call()`
     HALT_PERIOD = 2713
 
-    # based on inflation halt transaction time (https://etherscan.io/tx/0x23ef7eacd809399ed5135d5fe7dd9f6970c813f2704f884a12842479c213a87c)
-    HALT_NU_DATETIME = MayaDT.from_iso8601('2021-12-31T07:44:37.0Z')
-
     """
     Dash Status application for monitoring a swarm of nucypher Ursula nodes.
     """
@@ -68,9 +65,8 @@ class Dashboard:
             frozen_total_supply = NU.from_nunits(frozen_total_supply_nunits)
             parameter = request.args.get('q')
             if parameter is None or parameter == 'est_circulating_supply':
-                # max supply needed
-                max_supply_nunits = self.token_agent.contract.functions.totalSupply().call()
-                max_supply = NU.from_nunits(max_supply_nunits)
+                # the original max supply no longer applies because of Threshold merger
+                max_supply = frozen_total_supply
 
                 # worklock supply
                 worklock_supply = NU.from_nunits(self.worklock_agent.lot_value)
@@ -78,8 +74,7 @@ class Dashboard:
                 # no query - return all supply information
                 supply_info = calculate_supply_information(max_supply=max_supply,
                                                            current_total_supply=frozen_total_supply,
-                                                           worklock_supply=worklock_supply,
-                                                           now=self.HALT_NU_DATETIME)
+                                                           worklock_supply=worklock_supply)
                 if parameter is None:
                     # return all information
                     response = flask_server.response_class(

--- a/monitor/supply.py
+++ b/monitor/supply.py
@@ -147,7 +147,8 @@ def calculate_supply_information(max_supply: NU,
     # Current Total Supply
     supply_info['current_total_supply'] = float(initial_supply_with_rewards.to_tokens())
 
-    # Est. Circulating Supply
-    supply_info['est_circulating_supply'] = float(total_unlocked_allocations.to_tokens())
+    # Est. Circulating Supply = total unlocked + rewards
+    est_circulating_supply = total_unlocked_allocations + staking_rewards_issued
+    supply_info['est_circulating_supply'] = float(est_circulating_supply.to_tokens())
     return supply_info
 

--- a/tests/test_supply.py
+++ b/tests/test_supply.py
@@ -243,8 +243,9 @@ def verify_supply_information(supply_information: Dict,
     # Staking Rewards
     assert (supply_information['staking_rewards_supply']['total_allocated'] ==
             float((max_supply - INITIAL_SUPPLY).to_tokens()))
+    staking_rewards_issued = initial_supply_with_rewards - INITIAL_SUPPLY
     assert (supply_information['staking_rewards_supply']['staking_rewards_issued'] ==
-            float((initial_supply_with_rewards - INITIAL_SUPPLY).to_tokens()))
+            float(staking_rewards_issued.to_tokens()))
     assert (supply_information['staking_rewards_supply']['staking_rewards_remaining'] ==
             float((max_supply - initial_supply_with_rewards).to_tokens()))
 
@@ -252,7 +253,7 @@ def verify_supply_information(supply_information: Dict,
     assert supply_information['max_supply'] == float(max_supply.to_tokens())
 
     # Circulating Supply
-    assert supply_information['est_circulating_supply'] == float(total_unlocked.to_tokens())
+    assert supply_information['est_circulating_supply'] == float((total_unlocked + staking_rewards_issued).to_tokens())
 
 
 @pytest.mark.parametrize('months_transpired', [0, 3, 5])


### PR DESCRIPTION
- Update NU circulating supply to include issued rewards.
- Update max supply value to equal total current supply - due to Threshold merger.
- No longer use static halt NU inflation date (Dec 31, 2021) for vesting calculations.

Output for Today (Jan 28, 2022):
```json
{
   "initial_supply":{
      "total_allocated":1000000000,
      "locked_allocations":{
         "saft2":30000000.000000004,
         "team":39750000,
         "company":200000000,
         "worklock":0,
         "university":19500000
      },
      "unlocked_allocations":{
         "saft1":319000000,
         "casi":9000000,
         "vested":341250000,
         "ecosystem":41500000
      }
   },
   "staking_rewards_supply":{
      "total_allocated":380688920.64425474,
      "staking_rewards_issued":380688920.64425474,
      "staking_rewards_remaining":0
   },
   "max_supply":1380688920.6442547,
   "current_total_supply":1380688920.6442547,
   "est_circulating_supply":1091438920.6442547
}
```
